### PR TITLE
Add mutations-input-type rule

### DIFF
--- a/docs/rules/mutations-input-type.md
+++ b/docs/rules/mutations-input-type.md
@@ -1,0 +1,48 @@
+# Mutations must take single input types (mutation-input-type)
+
+All mutations must take no arguments or a single non-nullable argument named
+input of a type with the suffix `Input`.
+
+## Rule Details
+
+Best practice is to have a unique `Input` type for every mutation. This is easier
+to use on the client side and allows us to add new fields to a mutation
+input without breaking the API.
+
+If a mutation really doesn't need arguments (eg only needs domain/user from the
+login context) that's fine too.
+
+Autofixer not available.
+
+Examples of **incorrect** code for this rule:
+
+```graphql
+type Mutation {
+  sampleMutation(arg1: Int, arg2: String): SampleMutationPayload
+}
+```
+
+```graphql
+type Mutation {
+  sampleMutation(input: [SampleMutationInput]): SampleMutationPayload
+}
+```
+
+```graphql
+type Mutation {
+  sampleMutation(parameters: SampleMutationInput!): SampleMutationPayload
+}
+```
+
+Examples of **correct** code for this rule:
+
+```graphql
+type Mutation {
+  sampleMutation(input: SampleMutationInput!): SampleMutationPayload
+  arglessMutation: ArglessMutationPayload
+}
+```
+
+## When Not To Use It
+
+If you have a mutation that you're sure will never need to change.

--- a/lib/rules/mutations-input-type.ts
+++ b/lib/rules/mutations-input-type.ts
@@ -1,0 +1,85 @@
+/**
+ * @fileoverview Ensure that all mutations take a single non-nullable input type with the suffix "Input" or have no arguments
+ * @author Ellen Finch
+ */
+
+import {
+  GraphQLESLintRule,
+  GraphQLESTreeNode,
+} from "@graphql-eslint/eslint-plugin";
+import { ObjectTypeDefinitionNode, ObjectTypeExtensionNode } from "graphql";
+
+const rule: GraphQLESLintRule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "All mutations must take a single non-nullable input type with the suffix `Input` or have no arguments",
+      category: "Best Practices",
+      url:
+        "https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/mutations-input-type.md",
+    },
+  },
+  create(context) {
+    const validatePayload = (
+      node:
+        | GraphQLESTreeNode<ObjectTypeExtensionNode>
+        | GraphQLESTreeNode<ObjectTypeDefinitionNode>
+    ) => {
+      if (node.name.value !== "Mutation") {
+        return;
+      }
+      node.rawNode().fields?.forEach((field) => {
+        if ((field.arguments?.length ?? 0) > 1) {
+          context.report({
+            node,
+            message: "Mutations must take zero or one argument",
+          });
+          return;
+        }
+        field.arguments?.forEach((arg) => {
+          if (arg.name.value !== "input") {
+            context.report({
+              node,
+              message: "Mutations must take a single argument named input",
+            });
+            return;
+          }
+          if (arg.type.kind === "ListType") {
+            context.report({
+              node,
+              message: "Mutation input must not be list type",
+            });
+            return;
+          }
+          if (arg.type.kind !== "NonNullType") {
+            context.report({
+              node,
+              message: "Mutation input must be non-nullable",
+            });
+            return;
+          }
+          if (
+            arg.type.type.kind !== "NamedType" ||
+            !arg.type.type.name.value.endsWith("Input")
+          ) {
+            context.report({
+              node,
+              message: "Mutation input must be a type with suffix `Input`",
+            });
+            return;
+          }
+        });
+      });
+    };
+
+    return {
+      ObjectTypeDefinition: validatePayload,
+      ObjectTypeExtension: validatePayload,
+    };
+  },
+};
+
+module.exports = rule;
+
+export default rule;

--- a/tests/lib/rules/mutations-input-type.ts
+++ b/tests/lib/rules/mutations-input-type.ts
@@ -1,0 +1,95 @@
+import { GraphQLRuleTester } from "@graphql-eslint/eslint-plugin";
+import rule from "../../../lib/rules/mutations-input-type";
+
+const ruleTester = new GraphQLRuleTester();
+
+ruleTester.runGraphQLTests("mutations-input-type", rule, {
+  valid: [
+    {
+      code: `
+type Mutation {
+  validMutation(input: validInput!): abcPayload
+  anotherOne(input: anotherInput!): bcdPayload
+}
+`,
+    },
+    {
+      code: `
+type Mutation {
+  validMutation(input: validInput!): abcPayload
+  arglessMutation: arglessPayload
+}
+
+extend type Mutation {
+  anotherOne(input: anotherInput!): bcdPayload
+}
+`,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+type Mutation {
+  invalid(arg1: Boolean, arg2: String): bcdPayload
+}
+`,
+      errors: 1,
+    },
+    {
+      code: `
+type Mutation {
+  invalid(input: [abcInput]): bcdPayload
+}
+`,
+      errors: 1,
+    },
+    {
+      code: `
+type Mutation {
+  invalid(input: abcInput): bcdPayload
+}
+`,
+      errors: 1,
+    },
+    {
+      code: `
+type Mutation {
+  invalid(arg: abcInput!): bcdPayload
+}
+`,
+      errors: 1,
+    },
+    {
+      code: `
+type Mutation {
+  invalid(input: abcArgument!): bcdPayload
+}
+`,
+      errors: 1,
+    },
+    {
+      code: `
+type Mutation {
+  validMutation(input: validInput!): abcPayload
+}
+
+extend type Mutation {
+  invalidOne(arg1: Boolean, arg2: String): bcdPayload
+}
+`,
+      errors: 1,
+    },
+    {
+      code: `
+type Mutation {
+  invalidMutation(input: abcArgument!): abcPayload
+}
+
+extend type Mutation {
+  another(input: bcdInput!, otherInfo: String): bcdPayload
+}
+`,
+      errors: 2,
+    },
+  ],
+});


### PR DESCRIPTION
Add a lint rule that checks that mutations take 
1) no arguments
or 
2) a single argument named input of a non-nullable type with suffix Input 