### PR TITLE
add all-lists-in-connections lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ Hot tips:
 - [mutations-inputs-unique](/docs/rules/mutations-inputs-unique.md)
 - [mutations-input-type](/docs/rules/mutations-input-type.md)
 - [public-descendants-public](/docs/rules/public-descendants-public.md)
+- [all-lists-in-connections](docs/rules/all-lists-in-connections.md)

--- a/docs/rules/all-lists-in-connections.md
+++ b/docs/rules/all-lists-in-connections.md
@@ -1,0 +1,51 @@
+# All long lists must be paginated (all-lists-in-connections)
+
+## Rule Details
+
+All lists must either be paginated according to the Relay spec or explicitly marked as not needing pagination because they're guaranteed to be small.
+
+Use the `@tinylist` directive to mark a list as small and not in need of pagination.
+
+Examples of **incorrect** code for this rule:
+
+```graphql
+type T1 {
+  val: [T2]
+}
+```
+
+Examples of **correct** code for this rule:
+
+_Edges on connections can be lists_
+
+```graphql
+type UserConnection {
+  pageInfo: PageInfo!
+  edges: [UserEdge!]! # this is ok to be a list, since it's an edge on a connection
+  totalCount: Int!
+}
+
+type PageInfo {
+  endCursor: String
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+}
+
+type UserEdge {
+  cursor: String!
+  node: User!
+}
+
+type User {
+  ...
+}
+```
+
+_Fields can be whitelisted to be lists_
+
+```graphql
+type T1 {
+  val: [T2] @tinylist
+}
+```

--- a/lib/rules/all-lists-in-connections.ts
+++ b/lib/rules/all-lists-in-connections.ts
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Lint rule to ensure that all lists are either paginated as part of connections, or marked as explicitly not needing pagination.
+ * @author Robbie Ostrow
+ */
+
+import { GraphQLESLintRule } from "@graphql-eslint/eslint-plugin";
+
+import { DirectiveNode } from "graphql";
+import { isListType } from "../utils/graphqlutils";
+
+const SHORT_LIST_DIRECTIVE = "tinylist";
+
+const rule: GraphQLESLintRule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: `Ensures that all list types are edges in connections, or marked as ${SHORT_LIST_DIRECTIVE}`,
+      category: "Best Practices",
+      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/all-lists-in-connections.md",
+    },
+  },
+  create(context) {
+    const hasShortListDirective = (
+      directives: readonly DirectiveNode[] | undefined
+    ): boolean => {
+      return Boolean(
+        directives?.find((x) => x.name.value === SHORT_LIST_DIRECTIVE)
+      );
+    };
+
+    return {
+      FieldDefinition(node) {
+        // if it has the directive, it's allowed to be a list
+        if (hasShortListDirective(node.directives)) {
+          return;
+        }
+
+        // if it's an edge type on a connection, it's allowed to be a list
+        // node typings don't include parent but it's there!
+        const nodeParentName: string = (node as any).parent.name.value;
+        if (
+          node.name.value === "edges" &&
+          nodeParentName.endsWith("Connection")
+        ) {
+          return;
+        }
+
+        if (isListType(node.rawNode().type)) {
+          context.report({
+            node,
+            message: `Lists must be paginated or marked as guaranteed to be short using the directive @${SHORT_LIST_DIRECTIVE}.`,
+          });
+          return;
+        }
+      },
+    };
+  },
+};
+
+module.exports = rule;
+
+export default rule;

--- a/lib/utils/graphqlutils.ts
+++ b/lib/utils/graphqlutils.ts
@@ -2,6 +2,20 @@ import { GraphQLESLintRuleContext } from "@graphql-eslint/eslint-plugin";
 import { NamedTypeNode, GraphQLSchema, TypeNode } from "graphql";
 
 /**
+ * Given a TypeNode, determine whether it is a list type, ignoring
+ * nullability.
+ */
+export const isListType = (type: TypeNode): boolean => {
+  if (type.kind === "ListType") {
+    return true;
+  }
+  if (type.kind === "NonNullType") {
+    return isListType(type.type);
+  }
+  return false;
+};
+
+/**
  * Given a TypeNode, extract the base NamedType.
  *
  * ExtractNamedType strips off ListTypes and NonNullTypes –

--- a/tests/lib/rules/all-lists-in-connections.test.ts
+++ b/tests/lib/rules/all-lists-in-connections.test.ts
@@ -1,0 +1,133 @@
+import { GraphQLRuleTester } from "@graphql-eslint/eslint-plugin";
+import rule from "../../../lib/rules/all-lists-in-connections";
+
+const ruleTester = new GraphQLRuleTester();
+
+ruleTester.runGraphQLTests("all-lists-in-connections", rule, {
+  valid: [
+    {
+      code: `
+type T {
+  users: Int!
+}
+`,
+    },
+    {
+      code: `
+type T {
+  users: UserConnection
+}
+
+type UserConnection {
+  pageInfo: PageInfo!
+  edges: [UserEdge!]!
+  totalCount: Int!
+}
+
+type PageInfo {
+  endCursor: String
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+}
+
+type UserEdge {
+  cursor: String!
+  node: User!
+}
+
+type User {
+  id: ID!
+  name: String
+}
+`,
+    },
+    {
+      code: `
+type T {
+  users: [User!]! @tinylist
+}
+
+type User {
+  id: ID!
+  name: String
+}
+`,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+type T {
+  users: [User!]!
+}
+
+type User {
+  id: ID!
+  name: String
+}
+`,
+      errors: 1,
+    },
+    {
+      code: `
+type T {
+  users: [User!]!
+  users1: [User]
+}
+
+type User {
+  id: ID!
+  name: String
+}
+`,
+      errors: 2,
+    },
+    {
+      code: `
+type T {
+  users: [User!]! @tinylist
+  users1: [User!]
+}
+
+type User {
+  id: ID!
+  name: String
+}
+`,
+      errors: 1,
+    },
+    {
+      code: `
+type T {
+  users: UserConnection
+}
+
+type UserConnection {
+  pageInfo: PageInfo!
+  edges: [UserEdge!]!
+  notEdges: [UserEdge!]! # this shouldn't be a list
+  totalCount: Int!
+}
+
+type PageInfo {
+  endCursor: String
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+}
+
+type UserEdge {
+  cursor: String!
+  node: User!
+}
+
+type User {
+  id: ID!
+  name: String
+}
+`,
+      errors: 1,
+    },
+  ],
+});


### PR DESCRIPTION
## Changes
Introduce a new lint rule enforcing that all lists must either be paginated according to the Relay spec or explicitly marked as not needing pagination because they're guaranteed to be small.

Use the `@tinylist` directive to mark a list as small and not in need of pagination.

## Motivation
[ch-35488]

## Testing
See all the fancy new tests!