### PR TITLE
eslint-plugin-vanta: Rename references from master to main

### DIFF
--- a/docs/rules/errors-implement-usererror.md
+++ b/docs/rules/errors-implement-usererror.md
@@ -38,4 +38,4 @@ type PasswordTooWeakError {
 ```
 
 ## When Not To Use It
-Do not use this for developer errors. Then again, you should probably revisit the [GraphQL style guide](https://github.com/VantaInc/obsidian/blob/master/web/server/src/graphql/style.md#22-guidelines-for-errors) if you're adding developer error graphql types. 
+Do not use this for developer errors. Then again, you should probably revisit the [GraphQL style guide](https://github.com/VantaInc/obsidian/blob/main/web/server/src/graphql/style.md#22-guidelines-for-errors) if you're adding developer error graphql types.

--- a/graphql-style.md
+++ b/graphql-style.md
@@ -411,7 +411,7 @@ This way, adding new error types to the union doesn't break clients.
 
 > Relevant lint rules:
 >
-> - [errors-implement-usererror](https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/errors-implement-usererror.md) (link to lint rule enforcing A type should extend the `UserError` interface iff its name ends with `Error`)
+> - [errors-implement-usererror](https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/errors-implement-usererror.md) (link to lint rule enforcing A type should extend the `UserError` interface iff its name ends with `Error`)
 
 ### 2.2.2. Use the GraphQL `errors` key to return other errors
 
@@ -584,9 +584,9 @@ type PasswordTooWeakError implements UserError {
 
 > Relevant lint rules:
 >
-> - [mutations-return-payload](https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/mutations-return-payload.md)
-> - [mutations-payloads-unique](https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/mutations-payloads-unique.md)
-> - [payloads-are-unions](https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/payloads-are-unions.md)
+> - [mutations-return-payload](https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/mutations-return-payload.md)
+> - [mutations-payloads-unique](https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/mutations-payloads-unique.md)
+> - [payloads-are-unions](https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/payloads-are-unions.md)
 
 ### 2.3.3. Mutations must take a single, unique argument called `input`
 
@@ -594,8 +594,8 @@ Having a unique `input` type for each mutation makes it easier for clients to pa
 
 > Relevant lint rules:
 >
-> - [mutation-input-type](https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/mutations-input-type.md)
-> - [mutations-inputs-unique](https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/mutations-inputs-unique.md)
+> - [mutation-input-type](https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/mutations-input-type.md)
+> - [mutations-inputs-unique](https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/mutations-inputs-unique.md)
 
 ### 2.3.4. When in doubt, write 2 mutations
 
@@ -748,7 +748,7 @@ See the [pagination section](#25-pagination) for details about pagination.
 
 > Relevant lint rules:
 >
-> - [all-lists-in-connections](https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/all-lists-in-connections.md) (List types must be parts of connections or be whitelisted as constant length)
+> - [all-lists-in-connections](https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/all-lists-in-connections.md) (List types must be parts of connections or be whitelisted as constant length)
 
 ## 2.5. Pagination
 
@@ -758,8 +758,8 @@ We use [relay-style pagination](https://relay.dev/graphql/connections.htm). I wo
 
 > Relevant lint rules:
 >
-> - [connections-are-relay-compliant](https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/connections-are-relay-compliant.md) (Any type that ends in `Connection` must be a relay connection.)
-> - [edges-are-relay-compliant](https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/edges-are-relay-compliant.md) (Any type that ends in `edge` must be a relay edge)
+> - [connections-are-relay-compliant](https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/connections-are-relay-compliant.md) (Any type that ends in `Connection` must be a relay connection.)
+> - [edges-are-relay-compliant](https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/edges-are-relay-compliant.md) (Any type that ends in `edge` must be a relay edge)
 
 ### 2.5.2. No more than 100 results per page
 
@@ -1009,7 +1009,7 @@ All queries and mutations must have an explicit authorization rule defined.
 
 Individual types and fields can also define authorization rules, but it's less common that this is necessary.
 
-To prevent graph traversal vulnerabilities, ensure that the graph is structured in such a way that sensitive fields are never accessible from non-sensitive fields. See the [@public directive lint rule](https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/public-descendants-public.md) for more information.
+To prevent graph traversal vulnerabilities, ensure that the graph is structured in such a way that sensitive fields are never accessible from non-sensitive fields. See the [@public directive lint rule](https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/public-descendants-public.md) for more information.
 
 ## 3.7. Do not use GraphQL as an IPC layer
 

--- a/lib/rules/all-lists-in-connections.ts
+++ b/lib/rules/all-lists-in-connections.ts
@@ -15,7 +15,7 @@ const rule: GraphQLESLintRule = {
     docs: {
       description: `Ensures that all list types are edges in connections, or marked as ${SHORT_LIST_DIRECTIVE}`,
       category: "Best Practices",
-      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/all-lists-in-connections.md",
+      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/all-lists-in-connections.md",
     },
   },
   create(context) {

--- a/lib/rules/common-absolute-import.ts
+++ b/lib/rules/common-absolute-import.ts
@@ -6,7 +6,7 @@ import { ESLintUtils } from "@typescript-eslint/experimental-utils";
 
 const rule = ESLintUtils.RuleCreator(
   (ruleName) =>
-    `https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/${ruleName}.md`
+    `https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/${ruleName}.md`
 )<unknown[], "default">({
   name: "common-absolute-import",
   meta: {

--- a/lib/rules/connections-are-relay-compliant.ts
+++ b/lib/rules/connections-are-relay-compliant.ts
@@ -17,7 +17,7 @@ const rule: GraphQLESLintRule = {
       description:
         "All Connection GraphQL types must implement the interface specified by the Relay cursor spec.",
       category: "Best Practices",
-      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/connections-are-relay-compliant.md",
+      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/connections-are-relay-compliant.md",
     },
   },
   create(context) {

--- a/lib/rules/edges-are-relay-compliant.ts
+++ b/lib/rules/edges-are-relay-compliant.ts
@@ -22,7 +22,7 @@ const rule: GraphQLESLintRule = {
       description:
         "All Edge GraphQL types must implement the interface specified by the Relay cursor spec.",
       category: "Best Practices",
-      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/edges-are-relay-compliant.md",
+      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/edges-are-relay-compliant.md",
     },
   },
   create(context) {

--- a/lib/rules/errors-implement-usererror.ts
+++ b/lib/rules/errors-implement-usererror.ts
@@ -19,7 +19,7 @@ const rule: GraphQLESLintRule = {
       description:
         "A type should implement the UserError interface if and only if its name ends with Error.",
       category: "Best Practices",
-      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/errors-implement-usererror.md",
+      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/errors-implement-usererror.md",
     },
   },
   create(context): GraphQLESLintRuleListener<false> {

--- a/lib/rules/mutations-input-type.ts
+++ b/lib/rules/mutations-input-type.ts
@@ -15,7 +15,7 @@ const rule: GraphQLESLintRule = {
       description:
         "All mutations must take a single non-nullable input type with the suffix `Input` or have no arguments",
       category: "Best Practices",
-      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/mutations-input-type.md",
+      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/mutations-input-type.md",
     },
   },
   create(context) {

--- a/lib/rules/mutations-inputs-unique.ts
+++ b/lib/rules/mutations-inputs-unique.ts
@@ -15,7 +15,7 @@ const rule: GraphQLESLintRule = {
     docs: {
       description: "All mutations must take a unique input type",
       category: "Best Practices",
-      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/mutations-inputs-unique.md",
+      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/mutations-inputs-unique.md",
     },
   },
   create(context) {

--- a/lib/rules/mutations-payloads-unique.ts
+++ b/lib/rules/mutations-payloads-unique.ts
@@ -14,7 +14,7 @@ const rule: GraphQLESLintRule = {
     docs: {
       description: "All mutations must return a unique type",
       category: "Best Practices",
-      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/mutations-payloads-unique.md",
+      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/mutations-payloads-unique.md",
     },
   },
   create(context) {

--- a/lib/rules/mutations-return-payload.ts
+++ b/lib/rules/mutations-return-payload.ts
@@ -15,7 +15,7 @@ const rule: GraphQLESLintRule = {
       description:
         "All mutations must return a nullable type with the suffix `Payload`",
       category: "Best Practices",
-      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/mutations-return-payload.md",
+      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/mutations-return-payload.md",
     },
   },
   create(context) {

--- a/lib/rules/null-or-undefined-check.ts
+++ b/lib/rules/null-or-undefined-check.ts
@@ -10,7 +10,7 @@ import {
 
 const rule = ESLintUtils.RuleCreator(
   (ruleName) =>
-    `https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/${ruleName}.md`
+    `https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/${ruleName}.md`
 )<unknown[], "default">({
   name: "null-or-undefined-check",
   meta: {

--- a/lib/rules/optional-always-maybe.ts
+++ b/lib/rules/optional-always-maybe.ts
@@ -10,7 +10,7 @@ import {
 
 const rule = ESLintUtils.RuleCreator(
   (ruleName) =>
-    `https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/${ruleName}.md`
+    `https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/${ruleName}.md`
 )<unknown[], "default">({
   name: "optional-always-maybe",
   meta: {

--- a/lib/rules/payloads-are-unions.ts
+++ b/lib/rules/payloads-are-unions.ts
@@ -11,7 +11,7 @@ const rule: GraphQLESLintRule = {
       description:
         "Payloads are unions of a success type and one or more error types",
       category: "Best Practices",
-      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/payloads-are-unions.md",
+      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/payloads-are-unions.md",
     },
   },
   create(context) {

--- a/lib/rules/prefer-maybe.ts
+++ b/lib/rules/prefer-maybe.ts
@@ -14,7 +14,7 @@ const NOTHING_TYPES = [
 
 const rule = ESLintUtils.RuleCreator(
   (ruleName) =>
-    `https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/${ruleName}.md`
+    `https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/${ruleName}.md`
 )<unknown[], "default">({
   name: "prefer-maybe",
   meta: {

--- a/lib/rules/public-descendants-public.ts
+++ b/lib/rules/public-descendants-public.ts
@@ -24,7 +24,7 @@ const rule: GraphQLESLintRule = {
       description:
         "Ensures that all types reachable from fields marked as @public are themselves marked as @public.",
       category: "Best Practices",
-      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/public-descendants-public.md",
+      url: "https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/public-descendants-public.md",
     },
   },
   create(context) {


### PR DESCRIPTION
## Changes
Change references from `eslint-plugin-vanta/master` to `.../main`

## Motivation
[[sc-38738](https://app.shortcut.com/vanta/story/38738/rename-eslint-plugin-vanta-master)]