### PR TITLE
Add linter that enforces mongoose naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Hot tips:
 - [null-or-undefined-check](/docs/rules/null-or-undefined-check.md)
 - [optional-always-maybe](/docs/rules/optional-always-maybe.md)
 - [prefer-maybe](/docs/rules/prefer-maybe.md)
+- [mongoose-naming-convention](/docs/rules/mongoose-naming-convention.md)
 
 ### GraphQL
 

--- a/docs/rules/mongoose-naming-convention.md
+++ b/docs/rules/mongoose-naming-convention.md
@@ -1,4 +1,4 @@
-# Follow naming conventions for Mongoose models and schemas.
+# Follow naming conventions for Mongoose models and schemas. (mongoose-naming-convention)
 
 Identifiers for mongoose models and schemas should always be appropriately suffixed with 'Fields', 'Doc', or 'Model', and must share the same prefix.
 

--- a/docs/rules/mongoose-naming-convention.md
+++ b/docs/rules/mongoose-naming-convention.md
@@ -1,0 +1,43 @@
+# Follow naming conventions for Mongoose models and schemas.
+
+Identifiers for mongoose models and schemas should always be appropriately suffixed with 'Fields', 'Doc', or 'Model', and must share the same prefix.
+
+## Rule Details
+
+For a collection X, we use the following naming conventions:
+
+```
+XFields = typeof schema;
+XDoc = XFields & mongoose.Document;
+XModel = model<XDoc>(schema, options);
+```
+
+Examples of **incorrect** code for this rule:
+
+```ts
+type CollectionDoc = Collection & mongoose.Document;
+```
+
+```ts
+type CollectionDocument = CollectionFields & mongoose.Document;
+```
+
+```ts
+const Collection = model<CollectionDoc>("Collection", CollectionSchema);
+```
+
+```ts
+type CollectionDoc = ColectionFields & mongoose.Document;
+```
+
+```ts
+const ColectionModel = model<CollectionDoc>("Collection", CollectionSchema);
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+type CollectionFields = typeof CollectionSchema;
+type CollectionDoc = CollectionFields & mongoose.Document;
+const collectionModel = model<CollectionDoc>(schema, options);
+```

--- a/docs/rules/mongoose-naming-convention.md
+++ b/docs/rules/mongoose-naming-convention.md
@@ -39,5 +39,5 @@ Examples of **correct** code for this rule:
 ```ts
 type CollectionFields = typeof CollectionSchema;
 type CollectionDoc = CollectionFields & mongoose.Document;
-const collectionModel = model<CollectionDoc>(schema, options);
+const CollectionModel = model<CollectionDoc>(schema, options);
 ```

--- a/lib/rules/mongoose-naming-convention.ts
+++ b/lib/rules/mongoose-naming-convention.ts
@@ -69,7 +69,7 @@ const rule = ESLintUtils.RuleCreator(
     const sourceCode = context.getSourceCode();
 
     return {
-      "TSTypeAliasDeclaration TSIntersectionType TSTypeReference": (
+      "TSTypeAliasDeclaration > TSIntersectionType > TSTypeReference": (
         node: TSESTree.TSTypeReference
       ): void => {
         if (
@@ -136,64 +136,65 @@ const rule = ESLintUtils.RuleCreator(
         });
         return;
       },
-      "VariableDeclaration CallExpression TSTypeReference": (
-        node: TSESTree.TSTypeReference
-      ): void => {
-        const callExpressionNode = context
-          .getAncestors()
-          .slice(-2)[0] as TSESTree.CallExpression;
-        if (
-          !MONGOOSE_MODEL_TYPE_NODE_IDENTIFIERS.has(
-            sourceCode.getText(callExpressionNode.callee)
-          )
-        ) {
-          return;
-        }
-        const variableDeclaratorNode = context
-          .getAncestors()
-          .slice(-3)[0] as TSESTree.VariableDeclarator;
-        const variableDeclarationName = sourceCode.getText(
-          variableDeclaratorNode.id
-        );
-        if (!variableDeclarationName.endsWith(EXPECTED_MODEL_VARIABLE_SUFFIX)) {
-          context.report({
-            node: variableDeclaratorNode.id,
-            messageId: "mongooseModelNaming",
-            data: {
-              variableName: sourceCode.getText(variableDeclaratorNode.id),
-            },
-          });
-          return;
-        }
-        const documentTypeName = sourceCode.getText(node);
-        if (!documentTypeName.endsWith(EXPECTED_TYPE_ALIAS_SUFFIX)) {
-          context.report({
-            node,
-            messageId: "mongooseModelDocumentTypeNaming",
-            data: {
-              documentTypeName,
-            },
-          });
-          return;
-        }
-        const variableDeclarationNamePrefix = variableDeclarationName.split(
-          EXPECTED_MODEL_VARIABLE_SUFFIX
-        )[0];
-        const documentTypeNamePrefix = documentTypeName.split(
-          EXPECTED_TYPE_ALIAS_SUFFIX
-        )[0];
-        if (variableDeclarationNamePrefix !== documentTypeNamePrefix) {
-          context.report({
-            node,
-            messageId: "mongooseModelDocumentTypeMismatch",
-            data: {
-              variableDeclarationNamePrefix,
-              documentTypeNamePrefix,
-            },
-          });
-          return;
-        }
-      },
+      "VariableDeclarator > CallExpression > TSTypeParameterInstantiation > TSTypeReference":
+        (node: TSESTree.TSTypeReference): void => {
+          const callExpressionNode = context
+            .getAncestors()
+            .slice(-2)[0] as TSESTree.CallExpression;
+          if (
+            !MONGOOSE_MODEL_TYPE_NODE_IDENTIFIERS.has(
+              sourceCode.getText(callExpressionNode.callee)
+            )
+          ) {
+            return;
+          }
+          const variableDeclaratorNode = context
+            .getAncestors()
+            .slice(-3)[0] as TSESTree.VariableDeclarator;
+          const variableDeclarationName = sourceCode.getText(
+            variableDeclaratorNode.id
+          );
+          if (
+            !variableDeclarationName.endsWith(EXPECTED_MODEL_VARIABLE_SUFFIX)
+          ) {
+            context.report({
+              node: variableDeclaratorNode.id,
+              messageId: "mongooseModelNaming",
+              data: {
+                variableName: sourceCode.getText(variableDeclaratorNode.id),
+              },
+            });
+            return;
+          }
+          const documentTypeName = sourceCode.getText(node);
+          if (!documentTypeName.endsWith(EXPECTED_TYPE_ALIAS_SUFFIX)) {
+            context.report({
+              node,
+              messageId: "mongooseModelDocumentTypeNaming",
+              data: {
+                documentTypeName,
+              },
+            });
+            return;
+          }
+          const variableDeclarationNamePrefix = variableDeclarationName.split(
+            EXPECTED_MODEL_VARIABLE_SUFFIX
+          )[0];
+          const documentTypeNamePrefix = documentTypeName.split(
+            EXPECTED_TYPE_ALIAS_SUFFIX
+          )[0];
+          if (variableDeclarationNamePrefix !== documentTypeNamePrefix) {
+            context.report({
+              node,
+              messageId: "mongooseModelDocumentTypeMismatch",
+              data: {
+                variableDeclarationNamePrefix,
+                documentTypeNamePrefix,
+              },
+            });
+            return;
+          }
+        },
     };
   },
 });

--- a/lib/rules/mongoose-naming-convention.ts
+++ b/lib/rules/mongoose-naming-convention.ts
@@ -30,7 +30,7 @@ const EXPECTED_MODEL_VARIABLE_SUFFIX = "Model";
 
 const rule = ESLintUtils.RuleCreator(
   (ruleName) =>
-    `https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/${ruleName}.md`
+    `https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/${ruleName}.md`
 )<
   unknown[],
   | "mongooseDocumentNaming"
@@ -77,9 +77,14 @@ const rule = ESLintUtils.RuleCreator(
         ) {
           return;
         }
-        const typeAliasDeclaration = context
-          .getAncestors()
-          .slice(-2)[0] as TSESTree.TSTypeAliasDeclaration;
+        const ancestors = context.getAncestors();
+        const intersection = ancestors.slice(
+          -1
+        )[0] as TSESTree.TSIntersectionType;
+        const typeAliasDeclaration = ancestors.slice(
+          -2
+        )[0] as TSESTree.TSTypeAliasDeclaration;
+
         const typeAliasName = typeAliasDeclaration.id.name;
         if (!typeAliasName.endsWith(EXPECTED_TYPE_ALIAS_SUFFIX)) {
           context.report({
@@ -95,9 +100,6 @@ const rule = ESLintUtils.RuleCreator(
           0,
           -EXPECTED_TYPE_ALIAS_SUFFIX.length
         );
-        const intersection = context
-          .getAncestors()
-          .slice(-1)[0] as TSESTree.TSIntersectionType;
         const siblingTypes = intersection.types.filter(
           (type) =>
             !MONGOOSE_DOCUMENT_TYPE_NODE_IDENTIFIERS.has(
@@ -140,9 +142,14 @@ const rule = ESLintUtils.RuleCreator(
       },
       "VariableDeclarator > CallExpression > TSTypeParameterInstantiation > TSTypeReference":
         (node: TSESTree.TSTypeReference): void => {
-          const callExpressionNode = context
-            .getAncestors()
-            .slice(-2)[0] as TSESTree.CallExpression;
+          const ancestors = context.getAncestors();
+          const callExpressionNode = ancestors.slice(
+            -2
+          )[0] as TSESTree.CallExpression;
+          const variableDeclaratorNode = ancestors.slice(
+            -3
+          )[0] as TSESTree.VariableDeclarator;
+
           if (
             !MONGOOSE_MODEL_TYPE_NODE_IDENTIFIERS.has(
               sourceCode.getText(callExpressionNode.callee)
@@ -150,9 +157,6 @@ const rule = ESLintUtils.RuleCreator(
           ) {
             return;
           }
-          const variableDeclaratorNode = context
-            .getAncestors()
-            .slice(-3)[0] as TSESTree.VariableDeclarator;
           const variableDeclarationName = sourceCode.getText(
             variableDeclaratorNode.id
           );

--- a/lib/rules/mongoose-naming-convention.ts
+++ b/lib/rules/mongoose-naming-convention.ts
@@ -91,9 +91,10 @@ const rule = ESLintUtils.RuleCreator(
           });
           return;
         }
-        const typeAliasNamePrefix = typeAliasName.split(
-          EXPECTED_TYPE_ALIAS_SUFFIX
-        )[0];
+        const typeAliasNamePrefix = typeAliasName.slice(
+          0,
+          -EXPECTED_TYPE_ALIAS_SUFFIX.length
+        );
         const intersection = context
           .getAncestors()
           .slice(-1)[0] as TSESTree.TSIntersectionType;
@@ -119,9 +120,10 @@ const rule = ESLintUtils.RuleCreator(
             });
             return;
           }
-          const siblingTypeNamePrefix = siblingTypeName.split(
-            EXPECTED_INTERSECTION_TYPE_NAME_SUFFIX
-          )[0];
+          const siblingTypeNamePrefix = siblingTypeName.slice(
+            0,
+            -EXPECTED_INTERSECTION_TYPE_NAME_SUFFIX.length
+          );
           if (typeAliasNamePrefix !== siblingTypeNamePrefix) {
             context.report({
               node: sibling,
@@ -177,12 +179,14 @@ const rule = ESLintUtils.RuleCreator(
             });
             return;
           }
-          const variableDeclarationNamePrefix = variableDeclarationName.split(
-            EXPECTED_MODEL_VARIABLE_SUFFIX
-          )[0];
-          const documentTypeNamePrefix = documentTypeName.split(
-            EXPECTED_TYPE_ALIAS_SUFFIX
-          )[0];
+          const variableDeclarationNamePrefix = variableDeclarationName.slice(
+            0,
+            -EXPECTED_MODEL_VARIABLE_SUFFIX.length
+          );
+          const documentTypeNamePrefix = documentTypeName.slice(
+            0,
+            -EXPECTED_TYPE_ALIAS_SUFFIX.length
+          );
           if (variableDeclarationNamePrefix !== documentTypeNamePrefix) {
             context.report({
               node,

--- a/lib/rules/mongoose-naming-convention.ts
+++ b/lib/rules/mongoose-naming-convention.ts
@@ -1,0 +1,203 @@
+/**
+ * @fileoverview Follow naming conventions for Mongoose models and schemas.
+ * For a collection X, we use the following naming conventions:
+ *
+ * XFields = typeof schema;
+ * XDoc = XFields & mongoose.Document;
+ * XModel = model<XDoc>(schema, options);
+ */
+
+import {
+  AST_NODE_TYPES,
+  TSESTree,
+  ESLintUtils,
+} from "@typescript-eslint/experimental-utils";
+
+const MONGOOSE_DOCUMENT_TYPE_NODE_IDENTIFIERS = new Set([
+  "mongoose.Document",
+  "Document",
+]);
+const MONGOOSE_MODEL_TYPE_NODE_IDENTIFIERS = new Set([
+  "mongoose.model",
+  "model",
+  "mongoose.Model",
+  "Model",
+]);
+
+const EXPECTED_TYPE_ALIAS_SUFFIX = "Doc";
+const EXPECTED_INTERSECTION_TYPE_NAME_SUFFIX = "Fields";
+const EXPECTED_MODEL_VARIABLE_SUFFIX = "Model";
+
+const rule = ESLintUtils.RuleCreator(
+  (ruleName) =>
+    `https://github.com/VantaInc/eslint-plugin-vanta/blob/master/docs/rules/${ruleName}.md`
+)<
+  unknown[],
+  | "mongooseDocumentNaming"
+  | "mongooseFieldsNaming"
+  | "mongooseDocumentFieldsMismatch"
+  | "mongooseModelNaming"
+  | "mongooseModelDocumentTypeNaming"
+  | "mongooseModelDocumentTypeMismatch"
+>({
+  name: "mongoose-naming-convention",
+  meta: {
+    docs: {
+      description:
+        "Follow naming conventions for Mongoose modules and schemas.",
+      recommended: "error",
+    },
+    messages: {
+      mongooseDocumentNaming:
+        "Type alias names for mongoose documents must be suffixed with 'Doc', got {{typeAliasName}}",
+      mongooseFieldsNaming:
+        "Types intersected with mongoose.Document must be suffixed with 'Fields', got {{typeName}}",
+      mongooseDocumentFieldsMismatch:
+        "Prefixes of type alias name for mongoose documents must match the prefixes of types unioned, got {{typeAliasNamePrefix}} and {{fieldTypeNamePrefix}}",
+      mongooseModelNaming:
+        "Mongoose models must be suffixed with 'Model', got {{variableName}}",
+      mongooseModelDocumentTypeNaming:
+        "Mongoose model initialized with type that is not suffixed by 'Doc', got {{documentTypeName}}",
+      mongooseModelDocumentTypeMismatch:
+        "Prefixes of variable declaration for mongoose models must match the prefix of document type, got {{variableDeclarationNamePrefix}} and {{documentTypeNamePrefix}}",
+    },
+    type: "suggestion",
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const sourceCode = context.getSourceCode();
+
+    return {
+      "TSTypeAliasDeclaration TSIntersectionType TSTypeReference": (
+        node: TSESTree.TSTypeReference
+      ): void => {
+        if (
+          !MONGOOSE_DOCUMENT_TYPE_NODE_IDENTIFIERS.has(sourceCode.getText(node))
+        ) {
+          return;
+        }
+        const typeAliasDeclaration = context
+          .getAncestors()
+          .slice(-2)[0] as TSESTree.TSTypeAliasDeclaration;
+        const typeAliasName = typeAliasDeclaration.id.name;
+        if (!typeAliasName.endsWith(EXPECTED_TYPE_ALIAS_SUFFIX)) {
+          context.report({
+            node: typeAliasDeclaration.id,
+            messageId: "mongooseDocumentNaming",
+            data: {
+              typeAliasName: typeAliasDeclaration.id.name,
+            },
+          });
+          return;
+        }
+        const typeAliasNamePrefix = typeAliasName.split(
+          EXPECTED_TYPE_ALIAS_SUFFIX
+        )[0];
+        const intersection = context
+          .getAncestors()
+          .slice(-1)[0] as TSESTree.TSIntersectionType;
+        const siblingTypes = intersection.types.filter(
+          (type) =>
+            !MONGOOSE_DOCUMENT_TYPE_NODE_IDENTIFIERS.has(
+              sourceCode.getText(type)
+            ) && type.type === AST_NODE_TYPES.TSTypeReference
+        );
+        siblingTypes.forEach((sibling) => {
+          const siblingTypeName = sourceCode.getText(
+            (sibling as TSESTree.TSTypeReference).typeName
+          );
+          if (
+            !siblingTypeName.endsWith(EXPECTED_INTERSECTION_TYPE_NAME_SUFFIX)
+          ) {
+            context.report({
+              node: sibling,
+              messageId: "mongooseFieldsNaming",
+              data: {
+                typeName: sourceCode.getText(sibling),
+              },
+            });
+            return;
+          }
+          const siblingTypeNamePrefix = siblingTypeName.split(
+            EXPECTED_INTERSECTION_TYPE_NAME_SUFFIX
+          )[0];
+          if (typeAliasNamePrefix !== siblingTypeNamePrefix) {
+            context.report({
+              node: sibling,
+              messageId: "mongooseDocumentFieldsMismatch",
+              data: {
+                typeAliasNamePrefix,
+                fieldTypeNamePrefix: siblingTypeNamePrefix,
+              },
+            });
+            return;
+          }
+        });
+        return;
+      },
+      "VariableDeclaration CallExpression TSTypeReference": (
+        node: TSESTree.TSTypeReference
+      ): void => {
+        const callExpressionNode = context
+          .getAncestors()
+          .slice(-2)[0] as TSESTree.CallExpression;
+        if (
+          !MONGOOSE_MODEL_TYPE_NODE_IDENTIFIERS.has(
+            sourceCode.getText(callExpressionNode.callee)
+          )
+        ) {
+          return;
+        }
+        const variableDeclaratorNode = context
+          .getAncestors()
+          .slice(-3)[0] as TSESTree.VariableDeclarator;
+        const variableDeclarationName = sourceCode.getText(
+          variableDeclaratorNode.id
+        );
+        if (!variableDeclarationName.endsWith(EXPECTED_MODEL_VARIABLE_SUFFIX)) {
+          context.report({
+            node: variableDeclaratorNode.id,
+            messageId: "mongooseModelNaming",
+            data: {
+              variableName: sourceCode.getText(variableDeclaratorNode.id),
+            },
+          });
+          return;
+        }
+        const documentTypeName = sourceCode.getText(node);
+        if (!documentTypeName.endsWith(EXPECTED_TYPE_ALIAS_SUFFIX)) {
+          context.report({
+            node,
+            messageId: "mongooseModelDocumentTypeNaming",
+            data: {
+              documentTypeName,
+            },
+          });
+          return;
+        }
+        const variableDeclarationNamePrefix = variableDeclarationName.split(
+          EXPECTED_MODEL_VARIABLE_SUFFIX
+        )[0];
+        const documentTypeNamePrefix = documentTypeName.split(
+          EXPECTED_TYPE_ALIAS_SUFFIX
+        )[0];
+        if (variableDeclarationNamePrefix !== documentTypeNamePrefix) {
+          context.report({
+            node,
+            messageId: "mongooseModelDocumentTypeMismatch",
+            data: {
+              variableDeclarationNamePrefix,
+              documentTypeNamePrefix,
+            },
+          });
+          return;
+        }
+      },
+    };
+  },
+});
+
+module.exports = rule;
+
+export default rule;

--- a/tests/lib/rules/mongoose-naming-convention.test.ts
+++ b/tests/lib/rules/mongoose-naming-convention.test.ts
@@ -35,6 +35,9 @@ ruleTester.run("mongoose-naming-convention", rule, {
     {
       code: `const UserModel = model<UserDoc>("User", UserSchema);`,
     },
+    {
+      code: `const DocumentModel = model<DocumentDoc>("Document", DocumentSchema);`,
+    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/mongoose-naming-convention.test.ts
+++ b/tests/lib/rules/mongoose-naming-convention.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @fileoverview Follow naming conventions for Mongoose models and schemas.
+ * For a collection X, we use the following naming conventions:
+ *
+ * XFields = typeof schema;
+ * XDoc = XFields & mongoose.Document;
+ * XModel = model<XDoc>(schema, options);
+ */
+
+import rule from "../../../lib/rules/mongoose-naming-convention";
+import { resolve } from "path";
+
+import { TSESLint } from "@typescript-eslint/experimental-utils";
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: resolve(
+    __dirname + "../../../../node_modules/@typescript-eslint/parser"
+  ),
+});
+
+ruleTester.run("mongoose-naming-convention", rule, {
+  valid: [
+    {
+      code: `type Foo = Bar & otherModule.Document;`,
+    },
+    {
+      code: `type CollectionDoc = CollectionFields & mongoose.Document;`,
+    },
+    {
+      code: `type CollectionDoc<S,G> = CollectionFields<S,G> & mongoose.Document;`,
+    },
+    {
+      code: `type CollectionDoc<S,G> = {} & mongoose.Document;`,
+    },
+    {
+      code: `const UserModel = model<UserDoc>("User", UserSchema);`,
+    },
+  ],
+  invalid: [
+    {
+      code: `type Collection = CollectionFields & mongoose.Document;`,
+      errors: [
+        {
+          messageId: "mongooseDocumentNaming",
+          line: 1,
+          column: 6,
+        },
+      ],
+    },
+    {
+      code: `type Collection = CollectionFields & Document;`,
+      errors: [
+        {
+          messageId: "mongooseDocumentNaming",
+          line: 1,
+          column: 6,
+        },
+      ],
+    },
+    {
+      code: `type CollectionDoc = Collection & mongoose.Document;`,
+      errors: [
+        {
+          messageId: "mongooseFieldsNaming",
+          line: 1,
+          column: 22,
+        },
+      ],
+    },
+    {
+      code: `type CollectionDoc = ColectionFields & mongoose.Document;`,
+      errors: [
+        {
+          messageId: "mongooseDocumentFieldsMismatch",
+          line: 1,
+          column: 22,
+        },
+      ],
+    },
+    {
+      code: `const User = model<UserDoc>("User", UserSchema);`,
+      errors: [
+        {
+          messageId: "mongooseModelNaming",
+          line: 1,
+          column: 7,
+        },
+      ],
+    },
+    {
+      code: `const UserModel = model<UserDocument>("User", UserSchema);`,
+      errors: [
+        {
+          messageId: "mongooseModelDocumentTypeNaming",
+          line: 1,
+          column: 25,
+        },
+      ],
+    },
+    {
+      code: `const UserModel = model<OtherDoc>("User", UserSchema);`,
+      errors: [
+        {
+          messageId: "mongooseModelDocumentTypeMismatch",
+          line: 1,
+          column: 25,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
https://app.shortcut.com/vanta/story/38520/create-lint-rule-for-naming-of-mongoose-models-and-schemas
[sc-38520]

Tested by running against our main repo - surfaced 6 errors that all seemed reasonable to suppress or update.