### PR TITLE
Create an import rule and fix for server-common imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Hot tips:
 ### TypeScript
 
 - [common-absolute-import](/docs/rules/common-absolute-import.md)
+- [server-common-absolute-import](/docs/rules/server-common-absolute-import.md)
 - [null-or-undefined-check](/docs/rules/null-or-undefined-check.md)
 - [optional-always-maybe](/docs/rules/optional-always-maybe.md)
 - [prefer-maybe](/docs/rules/prefer-maybe.md)

--- a/docs/rules/server-common-absolute-import.md
+++ b/docs/rules/server-common-absolute-import.md
@@ -1,0 +1,25 @@
+# Import server-common/ from its absolute path (server-common-absolute-import)
+
+Always import code from server-common/ from its absolute path.
+
+## Rule Details
+
+This rule aims to ensure that autoimports always work in CI.
+
+Autofixer available.
+
+Examples of **incorrect** code for this rule:
+
+```js
+import { Maybe } from "../../server-common/src/base/maybe";
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import { Maybe } from "server-common/base/maybe";
+```
+
+## When Not To Use It
+
+If you have _correct_ import paths that look like "../server-common/src"

--- a/lib/absolute-import-rule.ts
+++ b/lib/absolute-import-rule.ts
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview Generic class that creates rules to enforce imports from {folder} are absolute
+ */
+
+import { ESLintUtils } from "@typescript-eslint/experimental-utils";
+
+const absoluteImportRule = (folder: string) => {
+  const ruleName = `${folder}-absolute-import`;
+
+  const rule = ESLintUtils.RuleCreator(
+    () =>
+      `https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/${ruleName}.md`
+  )<unknown[], "default">({
+    name: `${folder}-absolute-import`,
+    meta: {
+      fixable: "code",
+      docs: {
+        description: `Import ${folder} from its absolute path`,
+        recommended: "error",
+      },
+      messages: {
+        default: `Import code in ${folder} from its absolute path`,
+      },
+      type: "suggestion",
+      schema: [],
+    },
+    defaultOptions: [],
+    create(context) {
+      const badCommonImportRegex = new RegExp(
+        `\.\.\/.*\/?(${folder}\/)src\/(.*)`
+      );
+      //   const badCommonImportRegex = /\.\.\/.*\/?(server-common\/)src\/(.*)/s;
+      return {
+        ImportDeclaration(node) {
+          if (typeof node.source.value !== "string") {
+            return;
+          }
+          const matches = node.source.value.match(badCommonImportRegex);
+          if (!matches) {
+            return;
+          }
+          const replacement = node.source.value.replace(
+            badCommonImportRegex,
+            "$1$2"
+          );
+          context.report({
+            node,
+            messageId: "default",
+            fix(fixer) {
+              return [
+                fixer.replaceTextRange(
+                  [node.source.range[0] + 1, node.source.range[1] - 1],
+                  replacement
+                ),
+              ];
+            },
+          });
+        },
+      };
+    },
+  });
+
+  return rule;
+};
+
+module.exports = absoluteImportRule;
+
+export default absoluteImportRule;

--- a/lib/rules/common-absolute-import.ts
+++ b/lib/rules/common-absolute-import.ts
@@ -2,57 +2,9 @@
  * @fileoverview Ensure that imports from common/ are absolute instead of relative.
  */
 
-import { ESLintUtils } from "@typescript-eslint/experimental-utils";
+import absoluteImportRule from "../absolute-import-rule";
 
-const rule = ESLintUtils.RuleCreator(
-  (ruleName) =>
-    `https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/${ruleName}.md`
-)<unknown[], "default">({
-  name: "common-absolute-import",
-  meta: {
-    fixable: "code",
-    docs: {
-      description: "Import common/ from its absolute path",
-      recommended: "error",
-    },
-    messages: {
-      default: "Import code in common/ from its absolute path",
-    },
-    type: "suggestion",
-    schema: [],
-  },
-  defaultOptions: [],
-  create(context) {
-    const badCommonImportRegex = /\.\.\/.*\/?(common\/)src\/(.*)/s;
-    return {
-      ImportDeclaration(node) {
-        if (typeof node.source.value !== "string") {
-          return;
-        }
-        const matches = node.source.value.match(badCommonImportRegex);
-        if (!matches) {
-          return;
-        }
-        const replacement = node.source.value.replace(
-          badCommonImportRegex,
-          "$1$2"
-        );
-        context.report({
-          node,
-          messageId: "default",
-          fix(fixer) {
-            return [
-              fixer.replaceTextRange(
-                [node.source.range[0] + 1, node.source.range[1] - 1],
-                replacement
-              ),
-            ];
-          },
-        });
-      },
-    };
-  },
-});
+const rule = absoluteImportRule("common");
 
 module.exports = rule;
 

--- a/lib/rules/server-common-absolute-import.ts
+++ b/lib/rules/server-common-absolute-import.ts
@@ -1,0 +1,60 @@
+/**
+ * @fileoverview Ensure that imports from server-common/ are absolute instead of relative.
+ */
+
+ import { ESLintUtils } from "@typescript-eslint/experimental-utils";
+
+ const rule = ESLintUtils.RuleCreator(
+   (ruleName) =>
+     `https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/${ruleName}.md`
+ )<unknown[], "default">({
+   name: "server-common-absolute-import",
+   meta: {
+     fixable: "code",
+     docs: {
+       description: "Import server-common/ from its absolute path",
+       recommended: "error",
+     },
+     messages: {
+       default: "Import code in server-common/ from its absolute path",
+     },
+     type: "suggestion",
+     schema: [],
+   },
+   defaultOptions: [],
+   create(context) {
+     const badCommonImportRegex = /\.\.\/.*\/?(server-common\/)src\/(.*)/s;
+     return {
+       ImportDeclaration(node) {
+         if (typeof node.source.value !== "string") {
+           return;
+         }
+         const matches = node.source.value.match(badCommonImportRegex);
+         if (!matches) {
+           return;
+         }
+         const replacement = node.source.value.replace(
+           badCommonImportRegex,
+           "$1$2"
+         );
+         context.report({
+           node,
+           messageId: "default",
+           fix(fixer) {
+             return [
+               fixer.replaceTextRange(
+                 [node.source.range[0] + 1, node.source.range[1] - 1],
+                 replacement
+               ),
+             ];
+           },
+         });
+       },
+     };
+   },
+ });
+ 
+ module.exports = rule;
+ 
+ export default rule;
+ 

--- a/lib/rules/server-common-absolute-import.ts
+++ b/lib/rules/server-common-absolute-import.ts
@@ -2,59 +2,10 @@
  * @fileoverview Ensure that imports from server-common/ are absolute instead of relative.
  */
 
- import { ESLintUtils } from "@typescript-eslint/experimental-utils";
+import absoluteImportRule from "../absolute-import-rule";
 
- const rule = ESLintUtils.RuleCreator(
-   (ruleName) =>
-     `https://github.com/VantaInc/eslint-plugin-vanta/blob/main/docs/rules/${ruleName}.md`
- )<unknown[], "default">({
-   name: "server-common-absolute-import",
-   meta: {
-     fixable: "code",
-     docs: {
-       description: "Import server-common/ from its absolute path",
-       recommended: "error",
-     },
-     messages: {
-       default: "Import code in server-common/ from its absolute path",
-     },
-     type: "suggestion",
-     schema: [],
-   },
-   defaultOptions: [],
-   create(context) {
-     const badCommonImportRegex = /\.\.\/.*\/?(server-common\/)src\/(.*)/s;
-     return {
-       ImportDeclaration(node) {
-         if (typeof node.source.value !== "string") {
-           return;
-         }
-         const matches = node.source.value.match(badCommonImportRegex);
-         if (!matches) {
-           return;
-         }
-         const replacement = node.source.value.replace(
-           badCommonImportRegex,
-           "$1$2"
-         );
-         context.report({
-           node,
-           messageId: "default",
-           fix(fixer) {
-             return [
-               fixer.replaceTextRange(
-                 [node.source.range[0] + 1, node.source.range[1] - 1],
-                 replacement
-               ),
-             ];
-           },
-         });
-       },
-     };
-   },
- });
- 
- module.exports = rule;
- 
- export default rule;
- 
+const rule = absoluteImportRule("server-common");
+
+module.exports = rule;
+
+export default rule;

--- a/tests/lib/rules/common-absolute-import.test.ts
+++ b/tests/lib/rules/common-absolute-import.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Prefer isSome(expr) to checking against undefined or null
+ * @fileoverview Ensure that imports from common/ are absolute instead of relative.
  * @author Robbie Ostrow
  */
 
@@ -14,7 +14,7 @@ const ruleTester = new TSESLint.RuleTester({
   ),
 });
 
-ruleTester.run("prefer-maybe", rule, {
+ruleTester.run("common-absolute-import", rule, {
   valid: [
     {
       code: `import * as _ from "lodash"`,

--- a/tests/lib/rules/common-absolute-import.test.ts
+++ b/tests/lib/rules/common-absolute-import.test.ts
@@ -1,6 +1,5 @@
 /**
  * @fileoverview Ensure that imports from common/ are absolute instead of relative.
- * @author Robbie Ostrow
  */
 
 import rule from "../../../lib/rules/common-absolute-import";

--- a/tests/lib/rules/null-or-undefined-check.test.ts
+++ b/tests/lib/rules/null-or-undefined-check.test.ts
@@ -1,6 +1,5 @@
 /**
  * @fileoverview Prefer isSome(expr) to checking against undefined or null
- * @author Robbie Ostrow
  */
 
 import rule from "../../../lib/rules/null-or-undefined-check";

--- a/tests/lib/rules/optional-always-maybe.test.ts
+++ b/tests/lib/rules/optional-always-maybe.test.ts
@@ -1,6 +1,5 @@
 /**
  * @fileoverview Prefer isSome(expr) to checking against undefined or null
- * @author Robbie Ostrow
  */
 
 import rule from "../../../lib/rules/optional-always-maybe";

--- a/tests/lib/rules/prefer-maybe.test.ts
+++ b/tests/lib/rules/prefer-maybe.test.ts
@@ -1,6 +1,5 @@
 /**
  * @fileoverview Prefer isSome(expr) to checking against undefined or null
- * @author Robbie Ostrow
  */
 
 import rule from "../../../lib/rules/prefer-maybe";

--- a/tests/lib/rules/server-common-absolute-import.test.ts
+++ b/tests/lib/rules/server-common-absolute-import.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview Ensure that imports from server-common/ are absolute instead of relative.
+ * @author Robbie Ostrow
+ */
+
+ import rule from "../../../lib/rules/server-common-absolute-import";
+ import { resolve } from "path";
+ 
+ import { TSESLint } from "@typescript-eslint/experimental-utils";
+ 
+ const ruleTester = new TSESLint.RuleTester({
+   parser: resolve(
+     __dirname + "../../../../node_modules/@typescript-eslint/parser"
+   ),
+ });
+ 
+ ruleTester.run("server-common-absolute-import", rule, {
+   valid: [
+     {
+       code: `import * as _ from "lodash"`,
+     },
+     {
+       code: `import { Maybe } from "server-common/base/types/maybe"`,
+     },
+     {
+       code: `import * as maybe from "server-common/base/types/maybe"`,
+     },
+     {
+       code: `import { Maybe } from "../server-common/base/types/maybe"`,
+     },
+   ],
+   invalid: [
+     {
+       code: `import { Maybe } from "../server-common/src/base/types/maybe"`,
+       output: `import { Maybe } from "server-common/base/types/maybe"`,
+       errors: [{ messageId: "default", line: 1, column: 1 }],
+     },
+     {
+       code: `import { Maybe } from "../../../../server-common/src/base/types/maybe"`,
+       output: `import { Maybe } from "server-common/base/types/maybe"`,
+       errors: [{ messageId: "default", line: 1, column: 1 }],
+     },
+     {
+       code: `
+ import {
+   Maybe,
+   Maybe2
+ } from "../server-common/src/base/types/maybe"`,
+       output: `
+ import {
+   Maybe,
+   Maybe2
+ } from "server-common/base/types/maybe"`,
+       errors: [{ messageId: "default", line: 2, column: 2 }],
+     },
+   ],
+ });

--- a/tests/lib/rules/server-common-absolute-import.test.ts
+++ b/tests/lib/rules/server-common-absolute-import.test.ts
@@ -1,6 +1,5 @@
 /**
  * @fileoverview Ensure that imports from server-common/ are absolute instead of relative.
- * @author Robbie Ostrow
  */
 
  import rule from "../../../lib/rules/server-common-absolute-import";


### PR DESCRIPTION
[sc-42537](https://app.shortcut.com/vanta/story/42537/update-common-absolute-imports-lint-rule-to-support-fixing-server-common-imports)

I created a separate, new rule because the documentation and hints are slightly different, and this felt simpler than adding a `server-` prefix in the existing code. Happy to update the existing rule if we think that's better.