### PR TITLE
Update import rule to not require parent directories

### DIFF
--- a/lib/absolute-import-rule.ts
+++ b/lib/absolute-import-rule.ts
@@ -27,9 +27,8 @@ const absoluteImportRule = (folder: string) => {
     defaultOptions: [],
     create(context) {
       const badCommonImportRegex = new RegExp(
-        `\.\.\/.*\/?(${folder}\/)src\/(.*)`
+        `(\.\.\/)*?(${folder}\/)src\/(.*)`
       );
-      //   const badCommonImportRegex = /\.\.\/.*\/?(server-common\/)src\/(.*)/s;
       return {
         ImportDeclaration(node) {
           if (typeof node.source.value !== "string") {
@@ -41,7 +40,7 @@ const absoluteImportRule = (folder: string) => {
           }
           const replacement = node.source.value.replace(
             badCommonImportRegex,
-            "$1$2"
+            "$2$3"
           );
           context.report({
             node,

--- a/tests/lib/rules/common-absolute-import.test.ts
+++ b/tests/lib/rules/common-absolute-import.test.ts
@@ -40,6 +40,11 @@ ruleTester.run("common-absolute-import", rule, {
       errors: [{ messageId: "default", line: 1, column: 1 }],
     },
     {
+      code: `import { Maybe } from "common/src/base/types/maybe"`,
+      output: `import { Maybe } from "common/base/types/maybe"`,
+      errors: [{ messageId: "default", line: 1, column: 1 }],
+    },
+    {
       code: `
 import {
   Maybe,

--- a/tests/lib/rules/server-common-absolute-import.test.ts
+++ b/tests/lib/rules/server-common-absolute-import.test.ts
@@ -40,6 +40,11 @@
        errors: [{ messageId: "default", line: 1, column: 1 }],
      },
      {
+      code: `import { Maybe } from "server-common/src/base/types/maybe"`,
+      output: `import { Maybe } from "server-common/base/types/maybe"`,
+      errors: [{ messageId: "default", line: 1, column: 1 }],
+    },
+    {
        code: `
  import {
    Maybe,


### PR DESCRIPTION
## Changes
Updated the `common` and `server-common` import rule to not require parent directory directory tokens.

## Motivation
We encounter this scenario now, and it seems like VSCode will auto-import with no parent directories sometimes. We still want to fix the path to not have a `src`.

## Testing
I added two unit tests to cover this case.