### PR TITLE
Add anchors for regex for import rule

### DIFF
--- a/lib/absolute-import-rule.ts
+++ b/lib/absolute-import-rule.ts
@@ -27,7 +27,7 @@ const absoluteImportRule = (folder: string) => {
     defaultOptions: [],
     create(context) {
       const badCommonImportRegex = new RegExp(
-        `(\.\.\/)*?(${folder}\/)src\/(.*)`
+        `^(\.\.\/)*(${folder}\/)src\/(.*)$`
       );
       return {
         ImportDeclaration(node) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vanta-inc/eslint-plugin-vanta",
-  "version": "0.0.5",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vanta-inc/eslint-plugin-vanta",
-      "version": "0.0.5",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "requireindex": "~1.1.0"

--- a/tests/lib/rules/common-absolute-import.test.ts
+++ b/tests/lib/rules/common-absolute-import.test.ts
@@ -27,6 +27,9 @@ ruleTester.run("common-absolute-import", rule, {
     {
       code: `import { Maybe } from "../common/base/types/maybe"`,
     },
+    {
+      code: `import { sanitize } from "../../server-common/src/server/htmlUtils"`,
+    }
   ],
   invalid: [
     {
@@ -56,6 +59,6 @@ import {
   Maybe2
 } from "common/base/types/maybe"`,
       errors: [{ messageId: "default", line: 2, column: 1 }],
-    },
+    }
   ],
 });

--- a/tests/lib/rules/server-common-absolute-import.test.ts
+++ b/tests/lib/rules/server-common-absolute-import.test.ts
@@ -57,5 +57,10 @@
  } from "server-common/base/types/maybe"`,
        errors: [{ messageId: "default", line: 2, column: 2 }],
      },
+     {
+      code: `import { sanitize } from "../../server-common/src/server/htmlUtils"`,
+      output: `import { sanitize } from "server-common/server/htmlUtils"`,
+      errors: [{ messageId: "default", line: 1, column: 1 }],
+     }
    ],
  });


### PR DESCRIPTION
## Changes
- Adds `^` and `$` to ensure that the regex matches the whole import and not the part.

## Motivation
Relative imports for `server-common` were being fixed with the common import rule, which isn't what we intend.

## Testing
I added a unit test to ensure that `server-common` fixes the import and that `common` doesn't.